### PR TITLE
Add LtiResourceCopyNotice

### DIFF
--- a/app/models/lti/pns/lti_resource_copy_notice_builder.rb
+++ b/app/models/lti/pns/lti_resource_copy_notice_builder.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+#
+# Copyright (C) 2024 - present Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+module Lti
+  module Pns
+    # Builds a notice informing a tool that an LTI resource was copied or
+    # re-copied into a context.
+    class LtiResourceCopyNoticeBuilder < NoticeBuilder
+      REQUIRED_PARAMS = %i[
+        source_context
+        source_resource_id
+        target_context
+        target_resource_id
+        copied_at
+      ].freeze
+
+      attr_reader :params
+
+      def initialize(params = {})
+        REQUIRED_PARAMS.each do |param_name|
+          raise ArgumentError, "Missing required parameter: #{param_name}" unless params[param_name]
+        end
+
+        @params = params
+        super()
+      end
+
+      def notice_type
+        Lti::Pns::NoticeTypes::RESOURCE_COPY
+      end
+
+      def custom_instructure_claims(_tool)
+        {}
+      end
+
+      def custom_ims_claims(_tool)
+        target_context = params[:target_context]
+        {
+          context: {
+            id: Lti::V1p1::Asset.opaque_identifier_for(target_context),
+            label: target_context.respond_to?(:course_code) ? target_context.course_code : nil,
+            title: target_context.respond_to?(:name) ? target_context.name : nil,
+            type: [Lti::SubstitutionsHelper::LIS_V2_ROLE_MAP[target_context.class] || target_context.class.to_s]
+          }.compact,
+          resource_id: params[:target_resource_id],
+          origin_resource_ids: [
+            {
+              context: Lti::V1p1::Asset.opaque_identifier_for(params[:source_context]),
+              resource_id: params[:source_resource_id]
+            }
+          ]
+        }
+      end
+
+      def notice_event_timestamp
+        params[:copied_at]
+      end
+
+      def user
+        nil
+      end
+
+      def variable_expander(_tool)
+        nil
+      end
+    end
+  end
+end

--- a/app/models/lti/pns/notice_types.rb
+++ b/app/models/lti/pns/notice_types.rb
@@ -23,8 +23,9 @@ module Lti
       HELLO_WORLD = "LtiHelloWorldNotice"
       ASSET_PROCESSOR_SUBMISSION = "LtiAssetProcessorSubmissionNotice"
       CONTEXT_COPY = "LtiContextCopyNotice"
+      RESOURCE_COPY = "LtiResourceCopyNotice"
 
-      ALL = [HELLO_WORLD, ASSET_PROCESSOR_SUBMISSION, CONTEXT_COPY].freeze
+      ALL = [HELLO_WORLD, ASSET_PROCESSOR_SUBMISSION, CONTEXT_COPY, RESOURCE_COPY].freeze
     end
   end
 end

--- a/config/feature_flags/interop_release_flags.yml
+++ b/config/feature_flags/interop_release_flags.yml
@@ -178,6 +178,20 @@ lti_context_copy_notice:
       state: allowed_on
     ci:
       state: allowed_on
+lti_resource_copy_notice:
+  state: hidden
+  shadow: true
+  applies_to: RootAccount
+  display_name: Send LtiResourceCopyNotices during Content Migrations
+  description: |-
+    Send a Platform Notice to LTI 1.3 tools that have subscribed
+    to the LtiResourceCopyNotice notice type when LTI resources are copied
+    or re-copied into a course.
+  environments:
+    development:
+      state: allowed_on
+    ci:
+      state: allowed_on
 lti_deep_linking_line_items:
   state: hidden
   display_name: LTI Deep Linking Line Items

--- a/doc/api/pns.md
+++ b/doc/api/pns.md
@@ -34,7 +34,8 @@ To register a Notice Handler (webhook), the tool has to call the platform notifi
     "notice_types_supported": [
       "LtiHelloWorldNotice",
       "LtiAssetProcessorSubmissionNotice",
-      "LtiContextCopyNotice"
+      "LtiContextCopyNotice",
+      "LtiResourceCopyNotice"
     ]
   },
 ...
@@ -149,3 +150,39 @@ Example notice content:
 `context`: metadata about the new LTI Context (Course)
 
 `origin_contexts`: array with 1 element: LTI Context id of the source course
+
+### LtiResourceCopyNotice
+
+LtiResourceCopyNotice is sent to registered notice handlers when an LTI resource is copied or re-copied into a course.
+
+Example notice content:
+
+```json
+{
+  "https://purl.imsglobal.org/spec/lti/claim/version": "1.3.0",
+  "https://purl.imsglobal.org/spec/lti/claim/notice": {
+    "id": "12345678-1234-1234-1234-1234567890ab",
+    "timestamp": "2025-03-19T11:24:25Z",
+    "type": "LtiResourceCopyNotice"
+  },
+  "https://purl.imsglobal.org/spec/lti/claim/context": {
+    "id": "target_context_id"
+  },
+  "https://purl.imsglobal.org/spec/lti/claim/resource_id": "target_resource_id",
+  "https://purl.imsglobal.org/spec/lti/claim/origin_resource_ids": [
+    {
+      "context": "source_context_id",
+      "resource_id": "source_resource_id"
+    }
+  ]
+}
+```
+
+#### Claims
+
+`context`: metadata about the target context
+
+`resource_id`: LTI resource id created in the target context
+
+`origin_resource_ids`: array of objects describing the origin LTI resource and context
+

--- a/spec/models/importers/lti_resource_link_importer_spec.rb
+++ b/spec/models/importers/lti_resource_link_importer_spec.rb
@@ -120,6 +120,23 @@ describe Importers::LtiResourceLinkImporter do
           expect(destination_course.lti_resource_links.first.custom).to eq custom_params
         end
       end
+
+      context "with lti_resource_copy_notice enabled" do
+        before do
+          destination_course.root_account.enable_feature!(:lti_resource_copy_notice)
+          migration.started_at = Time.zone.now
+          allow(Lti::PlatformNotificationService).to receive(:notify_tools_in_course)
+        end
+
+        it "sends a resource copy notice" do
+          expect(Lti::PlatformNotificationService).to receive(:notify_tools_in_course).with(
+            destination_course,
+            instance_of(Lti::Pns::LtiResourceCopyNoticeBuilder)
+          )
+
+          subject
+        end
+      end
     end
   end
 

--- a/spec/models/lti/pns/lti_resource_copy_notice_builder_spec.rb
+++ b/spec/models/lti/pns/lti_resource_copy_notice_builder_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative "../../../spec_helper"
+
+RSpec.describe Lti::Pns::LtiResourceCopyNoticeBuilder, type: :model do
+  let(:account) { account_model }
+  let(:developer_key) do
+    dk = DeveloperKey.new(
+      scopes: ["https://purl.imsglobal.org/spec/lti/scope/noticehandlers"],
+      account: account
+    )
+    dk.save!
+    dk
+  end
+  let(:tool) do
+    ContextExternalTool.new(
+      name: "Test Tool",
+      url: "https://www.test.tool.com",
+      consumer_key: "key",
+      shared_secret: "secret",
+      settings: { "platform" => "canvas" },
+      account:,
+      developer_key:,
+      root_account: account
+    )
+  end
+
+  let(:source_course) { course_model(account:) }
+  let(:target_course) { course_model(account:) }
+  let(:params) do
+    {
+      source_context: source_course,
+      source_resource_id: "src123",
+      target_context: target_course,
+      target_resource_id: "tgt456",
+      copied_at: copied_at
+    }
+  end
+  let(:copied_at) { Time.now.utc.iso8601 }
+
+  describe "#initialize" do
+    it "raises an error if required params are missing" do
+      expect { described_class.new(params.except(:source_context)) }.to raise_error(ArgumentError)
+      expect { described_class.new(params.except(:copied_at)) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#build" do
+    subject { described_class.new(params).build(tool) }
+
+    before do
+      allow(LtiAdvantage::Messages::JwtMessage).to receive(:create_jws).and_return("signed_jwt")
+      allow(Rails.application.routes.url_helpers).to receive(:lti_notice_handlers_url).and_return("https://example.com/notice_handler")
+    end
+
+    it "returns a notice" do
+      Timecop.freeze do
+        expect(subject).to eq({ jwt: "signed_jwt" })
+        expect(LtiAdvantage::Messages::JwtMessage).to have_received(:create_jws).with(
+          hash_including(
+            "https://purl.imsglobal.org/spec/lti/claim/notice" => {
+              "id" => anything,
+              "timestamp" => copied_at,
+              "type" => "LtiResourceCopyNotice"
+            },
+            "https://purl.imsglobal.org/spec/lti/claim/context" => hash_including(id: target_course.lti_context_id),
+            "https://purl.imsglobal.org/spec/lti/claim/resource_id" => "tgt456",
+            "https://purl.imsglobal.org/spec/lti/claim/origin_resource_ids" => [
+              {
+                context: source_course.lti_context_id,
+                resource_id: "src123"
+              }
+            ]
+          ),
+          anything
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement `LtiResourceCopyNotice` builder
- notify tools about resource copy via `LtiResourceLinkImporter`
- expose new notice type and feature flag
- document new notice
- test builder and importer behaviour
- refine payload to group origin context and resource ID together
